### PR TITLE
Fixes Rare 'nil player' Crash

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -44,7 +44,7 @@ local function check_for_expired_buffs (nth_tick_event)
     for player_index, buff_details in pairs(global.player_buffs) do
         for buff_name, buff_value in pairs(buff_details) do
             if buff_value["remaining_seconds"] == 0 then
-                reset_player_buff(player_index, buff_name)
+                pcall(reset_player_buff, player_index, buff_name)
             else
                buff_value["remaining_seconds"] = buff_value["remaining_seconds"] - 1
             end
@@ -68,11 +68,11 @@ script.on_event(defines.events.on_player_joined_game, function(event)
 end)
 
 script.on_event(defines.events.on_pre_player_left_game, function(event)
-    if global.player_buffs == nil then
+    if global.player_buffs == nil or global.player_buffs[event.player_index] == nil then
         return
     end
     for buff_name, buff_value in pairs(global.player_buffs[event.player_index]) do
-        reset_player_buff(event.player_index, buff_name)
+        pcall(reset_player_buff, event.player_index, buff_name)
     end
     global.player_buffs[event.player_index] = nil
 end)

--- a/control.lua
+++ b/control.lua
@@ -32,6 +32,8 @@ local function reset_player_buff (player_index, buff_name)
     if buff == nil then return end
 
     local p = game.get_player(player_index)
+    if p == nil then return end
+
     p[buff_name] = buff["default"]
     buff = nil
 end


### PR DESCRIPTION
I encountered what I believe was a race condition that triggered a nil player crash in the buff cleanup code. This change adds an extra safety check there to prevent this in the future.